### PR TITLE
Fix problem with noSelection-option by improving find of emptyValue

### DIFF
--- a/src/overrides/ComboBox.js
+++ b/src/overrides/ComboBox.js
@@ -24,10 +24,14 @@ Ext.define('Densa.overrides.ComboBox', {
         store.un('load', this._addNoSelection, this);
     },
 
+    _findNoSelectionEntry: function (record, id) {
+        return record.emptyValue ? true : false;
+    },
+
     _addNoSelection : function(store)
     {
         if (!store) store = this.getStore();
-        if (this.showNoSelection && store.find(this.valueField, null) == -1) {
+        if (this.showNoSelection && store.findBy(this._findNoSelectionEntry) == -1) {
             var row = new store.model();
             row.set(this.displayField, this.emptyText);
             row.emptyValue = true;


### PR DESCRIPTION
store.find didn't found the emptyValue and added a lot more entries
than one. Now the function is searching for .emptyValue=true
