### PR TITLE
Change csv-export name to export-utf8 to help detect encoding

### DIFF
--- a/src/grid/PanelController.js
+++ b/src/grid/PanelController.js
@@ -210,7 +210,7 @@ Ext.define('Densa.grid.PanelController', {
                 tag: 'a',
                 href: blobURL,
                 style: 'display:none;',
-                download: 'export.csv'
+                download: 'export-utf8.csv'
             });
             a.dom.click();
             a.remove();


### PR DESCRIPTION
This should help to prevent opening csv file via excel and openoffice
with wrong encoding complaining about broken letters. Added this info
to file-name because there is no other way.