### PR TITLE
Bindable fires savesuccess to be view independent

### DIFF
--- a/src/editWindow/WindowController.js
+++ b/src/editWindow/WindowController.js
@@ -59,8 +59,9 @@ Ext.define('Densa.editWindow.WindowController', {
             return false;
         }, this);
 
-        this.bindable.view.on('savesuccess', function() {
+        this.bindable.on('savesuccess', function() {
             this.fireViewEvent('savesuccess');
+            this.fireEvent('savesuccess');
         }, this);
     },
 
@@ -106,6 +107,7 @@ Ext.define('Densa.editWindow.WindowController', {
                         syncQueue.start({
                             success: function() {
                                 this.fireViewEvent('savesuccess');
+                                this.fireEvent('savesuccess');
                             },
                             scope: this
                         });
@@ -113,7 +115,9 @@ Ext.define('Densa.editWindow.WindowController', {
                         this.bindable.save();
                         this.bindable.getLoadedRecord().save({
                             callback: function(records, operation, success) {
-                                if (success) this.fireViewEvent('savesuccess');
+                                if (!success) return;
+                                this.fireViewEvent('savesuccess');
+                                this.fireEvent('savesuccess');
                             },
                             scope: this
                         });

--- a/src/form/PanelController.js
+++ b/src/form/PanelController.js
@@ -118,6 +118,7 @@ Ext.define('Densa.form.PanelController', {
                         this._loadedStore.sync({
                             success: function() {
                                 this.fireViewEvent('savesuccess');
+                                this.fireEvent('savesuccess');
                             },
                             scope: this
                         });
@@ -178,6 +179,7 @@ Ext.define('Densa.form.PanelController', {
                 this.getLoadedRecord().save({
                     success: function() {
                         this.fireViewEvent('savesuccess', this.getLoadedRecord());
+                        this.fireEvent('savesuccess', this.getLoadedRecord());
                         if (!this._loadedStore) {
                             //if we don't have a store we can't listen to 'write' event
                             this.load(this.getLoadedRecord());

--- a/src/grid/PanelController.js
+++ b/src/grid/PanelController.js
@@ -101,6 +101,7 @@ Ext.define('Densa.grid.PanelController', {
             this.view.getStore().sync({
                 success: function() {
                     this.fireViewEvent('savesuccess');
+                    this.fireEvent('savesuccess');
                 },
                 scope: this
             });

--- a/src/grid/controller/Bind.js
+++ b/src/grid/controller/Bind.js
@@ -72,12 +72,9 @@ Ext.define('Densa.grid.controller.Bind', {
         this.gridController.view.on('bindstore', this.onBindStore, this);
         if (grid.getStore()) this.onBindStore(grid.getStore());
 
-        // TODO: every binding must not have a view, optimize
-        if (this.bindable.view) {
-            this.bindable.view.on('savesuccess', function() {
-                this.gridController.view.getStore().reload();
-            }, this);
-        }
+        this.bindable.on('savesuccess', function() {
+            this.gridController.view.getStore().reload();
+        }, this);
 
         if (this.addButton) {
             this.addButton.on('click', function() {

--- a/src/mvc/ViewController.js
+++ b/src/mvc/ViewController.js
@@ -1,6 +1,15 @@
 Ext.define('Densa.mvc.ViewController', {
     extend: 'Deft.mvc.ViewController',
     optionalControl: null,
+
+    mixins: {
+        observable: 'Ext.util.Observable'
+    },
+
+    constructor: function(config) {
+        this.callParent(arguments);
+        this.mixins.observable.constructor.call(this, config);
+    },
     onViewInitialize: function()
     {
         if (this.optionalControl) {

--- a/src/mvc/bindable/Form.js
+++ b/src/mvc/bindable/Form.js
@@ -16,6 +16,9 @@ Ext.define('Densa.mvc.bindable.Form', {
         }
         if (!this.formController) Ext.Error.raise('formController config is required');
         if (!(this.formController instanceof Densa.form.PanelController)) Ext.Error.raise('formController config needs to be a Densa.form.PanelController');
+        this.formController.view.on('savesuccess', function() {
+            this.fireEvent('savesuccess');
+        }, this);
     },
 
     load: function(row, store)

--- a/src/mvc/bindable/Grid.js
+++ b/src/mvc/bindable/Grid.js
@@ -15,6 +15,9 @@ Ext.define('Densa.mvc.bindable.Grid', {
 
         //savesuccess is fired by gridController on sync after delete
         this.grid.on('savesuccess', this._reloadGrid, this);
+        this.grid.on('savesuccess', function() {
+            this.fireEvent('savesuccess');
+        }, this);
     },
 
     load: function(row, parentStore)

--- a/src/mvc/bindable/GridBinding.js
+++ b/src/mvc/bindable/GridBinding.js
@@ -12,7 +12,10 @@ Ext.define('Densa.mvc.bindable.GridBinding', {
         if (!this.grid) this.grid = this.bindableToGridController.gridController.view;
 
         this.callParent(arguments);
-        this.bindableToGridController.bindable.view.on('savesuccess', this._reloadGrid, this);
+        this.bindableToGridController.bindable.on('savesuccess', this._reloadGrid, this);
+        this.bindableToGridController.bindable.on('savesuccess', function() {
+            this.fireEvent('savesuccess');
+        }, this);
     },
 
     reset: function()

--- a/src/mvc/bindable/Multiple.js
+++ b/src/mvc/bindable/Multiple.js
@@ -18,6 +18,11 @@ Ext.define('Densa.mvc.bindable.Multiple', {
                 Ext.Error.raise('item is not a bindableController');
             }
         }
+        Ext.each(this.items, function(i) {
+            i.on('savesuccess', function() {
+                this.fireEvent('savesuccess');
+            }, this);
+        }, this);
     },
 
     load: function(row, store)

--- a/src/mvc/bindable/ParentAssociation.js
+++ b/src/mvc/bindable/ParentAssociation.js
@@ -27,6 +27,9 @@ Ext.define('Densa.mvc.bindable.ParentAssociation', {
             });
             this._parentRowStore.on('write', this._reloadLoadedRow, this);
         }
+        this.bindable.on('savesuccess', function () {
+            this.fireEvent('savesuccess');
+        }, this);
     },
 
     _reloadLoadedRow: function()

--- a/src/mvc/bindable/ViewController.js
+++ b/src/mvc/bindable/ViewController.js
@@ -49,6 +49,9 @@ Ext.define('Densa.mvc.bindable.ViewController', {
         }
         if (this.getSaveButton) this.getSaveButton().disable();
         if (this.getDeleteButton) this.getDeleteButton().disable();
+        this.bindable.on('savesuccess', function() {
+            this.fireEvent('savesuccess');
+        }, this);
     },
 
     _onStoreWrite: function()
@@ -175,6 +178,7 @@ Ext.define('Densa.mvc.bindable.ViewController', {
                     success: function() {
                         submitDeferred.resolve();
                         this.fireViewEvent('savesuccess');
+                        this.fireEvent('savesuccess');
                     },
                     failure: function() {
                         submitDeferred.reject();


### PR DESCRIPTION
Before it was needed to set view for grid.controller.Bind. Now it's
listening to bindable because this is always existing.