### PR TITLE
Set stateId for every column if not set.

### DIFF
--- a/src/overrides/GridColumn.js
+++ b/src/overrides/GridColumn.js
@@ -1,0 +1,10 @@
+//Override to fix problem with random reorder of user-ordered grid columns
+Ext4.define('Densa.overrides.GridColumn', {
+    override: 'Ext.grid.column.Column',
+    initComponent: function() {
+        if (!this.stateId && this.dataIndex) {
+            this.stateId = this.dataIndex;
+        }
+        return this.callParent(arguments);
+    }
+});


### PR DESCRIPTION
This fixes problem with random column order for user-changed grid-
column order after code changes for columns.