### PR TITLE
Set type attribute in a-tag to force mimetype.

### DIFF
--- a/src/grid/PanelController.js
+++ b/src/grid/PanelController.js
@@ -297,6 +297,7 @@ Ext.define('Densa.grid.PanelController', {
                 var a = this.view.el.createChild({
                     tag: 'a',
                     href: blobURL,
+                    type: config.mimeType,
                     style: 'display:none;',
                     download: config.filename
                 });


### PR DESCRIPTION
Win10 with firefox 60.2.1esr (32bit) detects zip-file. (makes sense
as excel-builder returns return-value from jszip-object.generate function